### PR TITLE
Update config properties

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/lambda/Configuration.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/Configuration.java
@@ -9,7 +9,6 @@ import static com.nordstrom.kafka.connect.lambda.InvocationFailure.DROP;
 public class Configuration {
 
     private static final int MAX_HTTP_PORT_NUMBER = 65536;
-    private final Optional<String> credentialsProfile;
     private final Optional<String> httpProxyHost;
     private final Optional<Integer> httpProxyPort;
     private final Optional<String> awsRegion;
@@ -19,21 +18,13 @@ public class Configuration {
     private final Optional<String> externalId;
 
 
-    public Configuration(final String credentialsProfile, final String httpProxyHost,
-                         final Integer httpProxyPort, final String awsRegion,
+    public Configuration(final String httpProxyHost,
+                         final Integer httpProxyPort,
+                         final String awsRegion,
                          final InvocationFailure failureMode,
-                         final String roleArn, final String sessionName,
+                         final String roleArn,
+                         final String sessionName,
                          final String externalId) {
-        /*
-         * String awsCredentialsProfile =
-         * System.getenv(CREDENTIALS_PROFILE_CONFIG_ENV); String awsProxyHost =
-         * System.getenv(_CONFIG_ENV); String awsProxyPort =
-         * System.getenv(HTTP_PROXY_PORT_CONFIG_ENV);
-         *
-         */
-        this.credentialsProfile =
-                Facility.isNotNullNorEmpty(credentialsProfile) ? Optional.of(credentialsProfile)
-                        : Optional.empty();
         this.httpProxyHost =
                 Facility.isNotNullNorEmpty(httpProxyHost) ? Optional.of(httpProxyHost) : Optional.empty();
         this.httpProxyPort = Facility.isNotNullAndInRange(httpProxyPort, 0, MAX_HTTP_PORT_NUMBER)
@@ -50,8 +41,7 @@ public class Configuration {
 
     }
 
-    public Configuration(final Optional<String> awsCredentialsProfile,
-                         final Optional<String> httpProxyHost,
+    public Configuration(final Optional<String> httpProxyHost,
                          final Optional<Integer> httpProxyPort,
                          final Optional<String> awsRegion,
                          final Optional<InvocationFailure> failureMode,
@@ -59,7 +49,6 @@ public class Configuration {
                          final Optional<String> sessionName,
                          final Optional<String> externalId) {
 
-        this.credentialsProfile = awsCredentialsProfile;
         this.httpProxyHost = httpProxyHost;
         this.httpProxyPort = httpProxyPort;
         this.awsRegion = awsRegion;
@@ -70,15 +59,10 @@ public class Configuration {
     }
 
     public static Configuration empty() {
-        return new Configuration(
-                Optional.empty(), Optional.empty(),
+        return new Configuration(Optional.empty(),
                 Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty(),
                 Optional.empty(), Optional.empty());
-    }
-
-    public Optional<String> getCredentialsProfile() {
-        return this.credentialsProfile;
     }
 
     public Optional<String> getHttpProxyHost() {

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
@@ -296,12 +296,12 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
                     + RETRY_BACKOFF_MILLIS_DEFAULT),
 
     // AWS assume role support options
-    CREDENTIALS_PROVIDER_CLASS_CONFIG("lambda.credentials.provider.class", "REQUIRED Class providing cross-account role assumption"),
-    CREDENTIALS_PROVIDER_CLASS_DEFAULT("com.amazonaws.auth.DefaultAWSCredentialsProviderChain", "Default provider chain if lambda.credentials.provider.class is not passed in"),
-    CREDENTIALS_PROVIDER_CONFIG_PREFIX("aws.credentials.provider.", "Note trailing '.'"),
-    ROLE_ARN_CONFIG("lambda.credentials.provider.role.arn", " REQUIRED AWS Role ARN providing the access"),
-    SESSION_NAME_CONFIG("lambda.credentials.provider.session.name", "REQUIRED Session name"),
-    EXTERNAL_ID_CONFIG("lambda.credentials.provider.external.id", "OPTIONAL (but recommended) External identifier used by the kafka-connect-lambda when assuming the role");
+    CREDENTIALS_PROVIDER_CLASS_CONFIG("aws.lambda.credentials.provider.class", "REQUIRED Class providing cross-account role assumption"),
+    CREDENTIALS_PROVIDER_CLASS_DEFAULT("com.amazonaws.auth.DefaultAWSCredentialsProviderChain", "Default provider chain if aws.lambda.credentials.provider.class is not passed in"),
+    CREDENTIALS_PROVIDER_CONFIG_PREFIX("aws.lambda.credentials.provider.", "Note trailing '.'"),
+    ROLE_ARN_CONFIG("aws.lambda.credentials.provider.role.arn", " REQUIRED AWS Role ARN providing the access"),
+    SESSION_NAME_CONFIG("aws.lambda.credentials.provider.session.name", "REQUIRED Session name"),
+    EXTERNAL_ID_CONFIG("aws.lambda.credentials.provider.external.id", "OPTIONAL (but recommended) External identifier used by the kafka-connect-lambda when assuming the role");
 
     private final String value;
     private final String documentation;

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkConnectorConfig.java
@@ -23,7 +23,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
 
   private static final long AWS_LAMBDA_INVOCATION_TIMEOUT_MS_DEFAULT = 5 * 60 * 1000L;
   private static final String AWS_REGION_DEFAULT = "us-west-2";
-  private static final String AWS_CREDENTIALS_PROFILE_DEFAULT = "";
   private static final String HTTP_PROXY_HOST_DEFAULT = "";
   private static final int HTTP_PROXY_PORT_DEFAULT = -1;
   private static final boolean AWS_LAMBDA_BATCH_ENABLED_DEFAULT = true;
@@ -45,7 +44,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
   private final String connectorName;
   private final String httpProxyHost;
   private final Integer httpProxyPort;
-  private final String awsCredentialsProfile;
   private final String awsFunctionArn;
   private final Duration invocationTimeout;
   private final InvocationMode invocationMode;
@@ -79,8 +77,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
 
     this.httpProxyHost = this.getString(ConfigurationKeys.HTTP_PROXY_HOST.getValue());
     this.httpProxyPort = this.getInt(ConfigurationKeys.HTTP_PROXY_PORT.getValue());
-
-    this.awsCredentialsProfile = this.getString(ConfigurationKeys.AWS_CREDENTIALS_PROFILE.getValue());
 
     this.awsFunctionArn = this.getString(ConfigurationKeys.AWS_LAMBDA_FUNCTION_ARN.getValue());
     this.invocationTimeout = Duration.ofMillis(this.getLong(ConfigurationKeys.AWS_LAMBDA_INVOCATION_TIMEOUT_MS.getValue()));
@@ -129,10 +125,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
 
   public Duration getInvocationTimeout() {
     return this.invocationTimeout;
-  }
-
-  public String getAwsCredentialsProfile() {
-    return this.awsCredentialsProfile;
   }
 
   public Integer getHttpProxyPort() {
@@ -219,10 +211,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
       .define(ConfigurationKeys.AWS_REGION.getValue(), Type.STRING, AWS_REGION_DEFAULT,
               Importance.LOW, ConfigurationKeys.AWS_REGION.getDocumentation())
 
-      .define(ConfigurationKeys.AWS_CREDENTIALS_PROFILE.getValue(), Type.STRING,
-              AWS_CREDENTIALS_PROFILE_DEFAULT, Importance.LOW,
-              ConfigurationKeys.AWS_CREDENTIALS_PROFILE.getDocumentation())
-
       .define(ConfigurationKeys.HTTP_PROXY_HOST.getValue(), Type.STRING, HTTP_PROXY_HOST_DEFAULT,
               Importance.LOW, ConfigurationKeys.HTTP_PROXY_HOST.getDocumentation())
 
@@ -280,8 +268,6 @@ public class LambdaSinkConnectorConfig extends AbstractConfig {
             "Boolean that determines if the messages will be batched together before sending them to aws lambda. By default is " + AWS_LAMBDA_BATCH_ENABLED_DEFAULT),
     AWS_REGION("aws.region",
             "AWS region to instantiate the Lambda client Default: " + AWS_REGION_DEFAULT),
-    AWS_CREDENTIALS_PROFILE("aws.credentials.profile",
-            " AWS credentials profile to use for the Lambda client, by default is empty and will use the DefaultAWSCredentialsProviderChain"),
 
     HTTP_PROXY_HOST("http.proxy.host",
             "Http proxy port to be configured for the Lambda client, by default is empty"),

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
@@ -46,7 +46,6 @@ public class LambdaSinkTask extends SinkTask {
             this.configuration.getTaskId());
 
     Configuration optConfigs =  new Configuration(
-                    this.configuration.getAwsCredentialsProfile(),
                     this.configuration.getHttpProxyHost(),
                     this.configuration.getHttpProxyPort(),
                     this.configuration.getAwsRegion(),

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/AwsLambdaUtilTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/AwsLambdaUtilTest.java
@@ -14,7 +14,7 @@ public class AwsLambdaUtilTest {
     @Test(expected = RequestTooLargeException.class)
     public void testCheckPayloadSizeForInvocationTypeWithInvocationFailureModeStopThrowsException() {
 
-        final Configuration testOptConfigs = new Configuration("test-profile", "testhost", 123, "test-region", InvocationFailure.STOP, "test-arn", "test-session", "test-external-id");
+        final Configuration testOptConfigs = new Configuration("testhost", 123, "test-region", InvocationFailure.STOP, "test-arn", "test-session", "test-external-id");
         final AwsLambdaUtil testUtil = new AwsLambdaUtil(testOptConfigs, new HashMap<>());
 
         testUtil.checkPayloadSizeForInvocationType("testpayload".getBytes(), InvocationType.RequestResponse, Instant.now(), new RequestTooLargeException("Request payload is too large!"));
@@ -26,7 +26,7 @@ public class AwsLambdaUtilTest {
         AwsLambdaUtil.InvocationResponse testResp = null;
         RequestTooLargeException ex = null;
 
-        final Configuration testOptConfigs = new Configuration("test-profile", "testhost", 123, "test-region", InvocationFailure.DROP, "test-arn", "test-session", "test-external-id");
+        final Configuration testOptConfigs = new Configuration("testhost", 123, "test-region", InvocationFailure.DROP, "test-arn", "test-session", "test-external-id");
         final AwsLambdaUtil testUtil = new AwsLambdaUtil(testOptConfigs, new HashMap<>());
 
         try {

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
@@ -30,15 +30,14 @@ public class LambdaSinkTaskTest {
         new ImmutableMap.Builder<String, String>()
                 .put("connector.class", "com.nordstrom.kafka.connect.lambda.LambdaSinkConnector")
                 .put("tasks.max", "1")
+                .put("aws.region", "test-region")
                 .put("aws.lambda.function.arn", "arn:aws:lambda:us-west-2:123456789123:function:test-lambda")
                 .put("aws.lambda.invocation.timeout.ms", "300000")
                 .put("aws.lambda.invocation.mode", "SYNC")
                 .put("aws.lambda.batch.enabled", "true")
-                .put("aws.lambda.json.wrapper.enabled", "true")
                 .put("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .put("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                 .put("topics", "connect-lambda-test")
-                .put("aws.credentials.profile", "my-profile")
                 .build();
 
         LambdaSinkTask task = new LambdaSinkTask();
@@ -51,12 +50,12 @@ public class LambdaSinkTaskTest {
         assertNotNull(task.lambdaClient);
 
         assertEquals("0", task.configuration.getTaskId());
+        assertEquals("test-region", task.configuration.getAwsRegion());
         assertEquals("arn:aws:lambda:us-west-2:123456789123:function:test-lambda", task.configuration.getAwsFunctionArn());
+        assertEquals("PT5M", task.configuration.getInvocationTimeout().toString());
         assertEquals("SYNC", task.configuration.getInvocationMode().toString());
-        assertEquals(6291455, task.configuration.getMaxBatchSizeBytes());
-        assertEquals("us-west-2", task.configuration.getAwsRegion());
-        assertEquals("my-profile", task.configuration.getAwsCredentialsProfile());
         assertTrue(task.configuration.isBatchingEnabled());
+        assertEquals(6291455, task.configuration.getMaxBatchSizeBytes());
     }
 
     @Ignore("Test is ignored as a demonstration -- needs profile")
@@ -71,11 +70,9 @@ public class LambdaSinkTaskTest {
                         .put("aws.lambda.invocation.timeout.ms", "300000")
                         .put("aws.lambda.invocation.mode", "SYNC")
                         .put("aws.lambda.batch.enabled", "false")
-                        .put("aws.lambda.json.wrapper.enabled", "true")
                         .put("key.converter", "org.apache.kafka.connect.storage.StringConverter")
                         .put("value.converter", "org.apache.kafka.connect.storage.StringConverter")
                         .put("topics", "connect-lambda-test")
-                        .put("aws.credentials.profile", "my-profile")
                         .build();
 
         LambdaSinkTask task = new LambdaSinkTask();
@@ -88,7 +85,6 @@ public class LambdaSinkTaskTest {
         AwsLambdaUtil mockedLambdaClient = mock(AwsLambdaUtil.class);
 
         when(mockedLambdaClient.invoke(anyString(), anyObject(), anyObject(), eq(InvocationType.RequestResponse))).thenReturn(new AwsLambdaUtil( new Configuration(
-                task.configuration.getAwsCredentialsProfile(),
                 task.configuration.getHttpProxyHost(),
                 task.configuration.getHttpProxyPort(),
                 task.configuration.getAwsRegion(),


### PR DESCRIPTION
Update the configuration properties to
- remove the unused `aws.credentials.profile` property
- ensure the credentials provider properties begin with `aws.lambda.credentials.provider.`