### PR TITLE
Use jackson 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Kafka Connect sink plugin to invoke AWS Lambda functions.
 ## Compatibility Matrix
 |kafka-connect-lambda|Kafka Connect API|AWS SDK|
 |:---|:---|:---|
-|1.1.0|2.1.0|1.11.592|
-|1.1.1|2.1.0|1.11.592|
+|1.1.0|2.2.0|1.11.592|
+|1.1.1|2.2.0|1.11.592|
 |1.2.0|2.3.0|1.11.651|
 
 Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.1 and earlier may not work with Kafka Connect versions greater than 2.2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A Kafka Connect sink plugin to invoke AWS Lambda functions.
 
+## Compatibility Matrix
+|kafka-connect-lambda|Kafka Connect API|AWS SDK|
+|:---|:---|:---|
+|1.1.0|2.1.0|1.11.592|
+|1.1.1|2.1.0|1.11.592|
+|1.2.0|2.3.0|1.11.651|
+
+NB: Due to a compatibility issue with Apache httpcomponents, kafka-connect-lambda-1.1.1 will NOT work with
+Confluent/kafka-connect-5.3.1 (API 2.3.0).
+
+Use kafka-connect-lambda-1.2.0 instead which should work with Confluent 5.2.1+.
+
 # Building
 
 Build the connector with Maven using the standard lifecycle goals:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ A Kafka Connect sink plugin to invoke AWS Lambda functions.
 |1.1.1|2.1.0|1.11.592|
 |1.2.0|2.3.0|1.11.651|
 
-NB: Due to a compatibility issue with Apache httpcomponents, kafka-connect-lambda-1.1.1 will NOT work with
-Confluent/kafka-connect-5.3.1 (API 2.3.0).
-
-Use kafka-connect-lambda-1.2.0 instead which should work with Confluent 5.2.1+.
+Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.1 and earlier may not work with Kafka Connect versions greater than 2.2
 
 # Building
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.1.3
+    image: confluentinc/cp-zookeeper:5.3.1
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     ports:
@@ -10,7 +10,7 @@ services:
     logging: { driver: none }
 
   broker:
-    image: confluentinc/cp-kafka:5.1.3
+    image: confluentinc/cp-kafka:5.3.1
     ports:
     - 9092:9092
     environment:
@@ -31,7 +31,7 @@ services:
     logging: { driver: none }
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.1.3
+    image: confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     ports:
     - 8080:8080
@@ -48,7 +48,7 @@ services:
 
   # NB: run connect locally in stand-alone mode to debug
   connect:
-    image: confluentinc/cp-kafka-connect:5.1.3
+    image: confluentinc/cp-kafka-connect:5.3.1
     ports:
     - 8083:8083
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     - KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:/etc/log4j.properties
 
     - AWS_PROFILE
+    - AWS_REGION
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
     volumes:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nordstrom.kafka.connect.lambda</groupId>
     <artifactId>kafka-connect-lambda</artifactId>
-    <version>1.1.1</version>
+    <version>2.3.0</version>
 
     <name>kafka-connect-lambda</name>
     <description>A Kafka Connect Connector for kafka-connect-lambda</description>
@@ -17,14 +17,13 @@
 
         <slf4j.version>1.7.25</slf4j.version>
 
-        <kafka-connect.version>2.1.0</kafka-connect.version>
+        <kafka-connect.version>2.3.0</kafka-connect.version>
         <!-- NB: must be consistent with version in kafka-connect -->
         <jackson.version>2.9.6</jackson.version>
         <aws-java-sdk.version>1.11.592</aws-java-sdk.version>
         <junit.version>4.12</junit.version>
         <mockito-core.version>2.28.2</mockito-core.version>
         <google.guava.version>19.0</google.guava.version>
-        <jackson.version>2.9.6</jackson.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nordstrom.kafka.connect.lambda</groupId>
     <artifactId>kafka-connect-lambda</artifactId>
-    <version>2.3.0</version>
+    <version>1.2.0</version>
 
     <name>kafka-connect-lambda</name>
     <description>A Kafka Connect Connector for kafka-connect-lambda</description>
@@ -20,12 +20,27 @@
         <kafka-connect.version>2.3.0</kafka-connect.version>
         <!-- NB: must be consistent with version in kafka-connect -->
         <jackson.version>2.9.6</jackson.version>
-        <aws-java-sdk.version>1.11.592</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.651</aws-java-sdk.version>
         <junit.version>4.12</junit.version>
         <mockito-core.version>2.28.2</mockito-core.version>
         <google.guava.version>19.0</google.guava.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            By using the BOM, we use aws sdk components that are compatible with each other and don't need to
+            specify their versions.
+            -->
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bom</artifactId>
+                <version>${aws-java-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -57,15 +72,18 @@
             <artifactId>jackson-dataformat-cbor</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!--
+         NB: aws-java-sdk-lambda defines the org.apache.httpcomponents httpclient, httpcore versions.
+         DO NOT exclude in shade. Kafka Connect will default to versions < 4.5.9 which result in
+         InvalidSignatureException
+         -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>
-            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -175,7 +193,6 @@
                                     <!-- provided by kafka-connect -->
                                     <exclude>commons-codec:*</exclude>
                                     <exclude>commons-logging:*</exclude>
-                                    <exclude>org.apache.httpcomponents:*</exclude>
                                     <exclude>org.apache.kafka:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>com.fasterxml.jackson.core:*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,6 @@
             <artifactId>jackson-dataformat-cbor</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-        <!--
-         NB: aws-java-sdk-lambda defines the org.apache.httpcomponents httpclient, httpcore versions.
-         DO NOT exclude in shade. Kafka Connect will default to versions < 4.5.9 which result in
-         InvalidSignatureException
-         -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,26 +46,31 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka-connect.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
             <version>${kafka-connect.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -188,7 +193,6 @@
                                     <!-- provided by kafka-connect -->
                                     <exclude>commons-codec:*</exclude>
                                     <exclude>commons-logging:*</exclude>
-                                    <exclude>org.apache.kafka:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>javax.ws.rs:*</exclude>
                                 </excludes>


### PR DESCRIPTION
Response to automatic github upgrade of jackson-core to 2.10.0.  Marked all relevant jars in Kafka Connect as provided in maven pom.xml which reduced explicit excludes in maven-share-plugin.  jar file size reduced from 10M to 4M.