### PR TITLE
Fixes #35 - Fail task upon function execution error

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/lambda/InvocationClient.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/InvocationClient.java
@@ -60,15 +60,15 @@ public class InvocationClient {
         try {
             final InvokeResult result = futureResult.get(invocationTimeout.toMillis(), TimeUnit.MILLISECONDS);
             return new InvocationResponse(result.getStatusCode(), result.getLogResult(),
-                    result.getFunctionError(), start, Instant.now());
+                    result.getFunctionError(), result.getPayload(), start, Instant.now());
         } catch (RequestTooLargeException e) {
             return checkPayloadSizeForInvocationType(payload, type, start, e);
         } catch (final InterruptedException | ExecutionException e) {
             LOGGER.error(e.getLocalizedMessage(), e);
             throw new InvocationException(e);
         } catch (final TimeoutException e) {
-            return new InvocationResponse(504, e.getLocalizedMessage(), e.getLocalizedMessage(), start,
-                    Instant.now());
+            return new InvocationResponse(504, e.getLocalizedMessage(), e.getLocalizedMessage(),
+                    null, start, Instant.now());
         }
     }
 
@@ -105,7 +105,7 @@ public class InvocationClient {
             throw e;
         }
         // Drop message and continue
-        return new InvocationResponse(413, e.getLocalizedMessage(), e.getLocalizedMessage(), start, Instant.now());
+        return new InvocationResponse(413, e.getLocalizedMessage(), e.getLocalizedMessage(), null, start, Instant.now());
     }
 
     private class InvocationException extends RuntimeException {

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/InvocationResponse.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/InvocationResponse.java
@@ -1,9 +1,13 @@
 package com.nordstrom.kafka.connect.lambda;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 
 public class InvocationResponse {
     private final String errorString;
+    private final ByteBuffer errorDescription;
     private final String responseString;
     private final Integer statusCode;
     private final Instant start;
@@ -13,12 +17,14 @@ public class InvocationResponse {
             final Integer statusCode,
             final String logResult,
             final String functionError,
+            final ByteBuffer errorDescription,
             final Instant start,
             final Instant end) {
 
         this.statusCode = statusCode;
         this.responseString = logResult;
         this.errorString = functionError;
+        this.errorDescription = errorDescription;
         this.start = start;
         this.end = end;
 
@@ -34,6 +40,11 @@ public class InvocationResponse {
 
     public String getErrorString() {
         return this.errorString;
+    }
+
+    public String getErrorDescription() {
+        Charset charset = StandardCharsets.UTF_8;
+        return charset.decode(this.errorDescription).toString();
     }
 
     public String getResponseString() {

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
@@ -210,7 +210,7 @@ public class LambdaSinkTask extends SinkTask {
 
     String functionError = response.getErrorString();
     // When the function execution fails the Lambda responds by setting either of these values
-    if (functionError.equals("Unhandled") || functionError.equals("Handled")) {
+    if (! functionError.isEmpty()) {
       throw new FunctionExecutionException(MessageFormat
               .format("Lambda function execution failed. Reason: {0}: {1}",
                       response.getErrorString(),

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
@@ -201,7 +201,7 @@ public class LambdaSinkTask extends SinkTask {
     return response;
   }
 
-  private void handleResponse(
+  void handleResponse(
           final InvocationResponse response,
           final AtomicInteger retryCount,
           final Collection<Integer> retriableErrorCodes,

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
@@ -207,12 +207,14 @@ public class LambdaSinkTask extends SinkTask {
           final Collection<Integer> retriableErrorCodes,
           final int maxRetries,
           final long backoffTimeMs) {
+
     String functionError = response.getErrorString();
     // When the function execution fails the Lambda responds by setting either of these values
     if (functionError.equals("Unhandled") || functionError.equals("Handled")) {
       throw new FunctionExecutionException(MessageFormat
-              .format("Lambda function execution failed. Msg: {0}",
-                      functionError
+              .format("Lambda function execution failed. Reason: {0}: {1}",
+                      response.getErrorString(),
+                      response.getErrorDescription()
               ));
     } else if (response.getStatusCode() < 300 && response.getStatusCode() >= 200) {
       //success
@@ -267,6 +269,7 @@ public class LambdaSinkTask extends SinkTask {
       super(message);
     }
   }
+
   protected static class FunctionExecutionException extends RuntimeException {
     FunctionExecutionException(final String message) {
       super(message);

--- a/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTask.java
@@ -209,8 +209,8 @@ public class LambdaSinkTask extends SinkTask {
           final long backoffTimeMs) {
 
     String functionError = response.getErrorString();
-    // When the function execution fails the Lambda responds by setting either of these values
     if (! functionError.isEmpty()) {
+      //function-error
       throw new FunctionExecutionException(MessageFormat
               .format("Lambda function execution failed. Reason: {0}: {1}",
                       response.getErrorString(),

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
@@ -9,15 +9,19 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,4 +62,30 @@ public class LambdaSinkTaskTest {
 
         task.put(testList);
     }
+
+    @Test(expected = LambdaSinkTask.FunctionExecutionException.class)
+    public void testHandleResponseWhenFunctionExecutionFails() {
+
+        LambdaSinkTask task = new LambdaSinkTask();
+
+        String msg = "{\"errorMessage\": \"foo\", \"errorType\": \"ValueError\", \"stackTrace\": [\"  File \\\"/var/task/lambda_function.py\\\", line 5, in lambda_handler\\n    raise ValueError(\\\"foo\\\")\\n\"]}";
+        ByteBuffer errorDescription = ByteBuffer.wrap(msg.getBytes(StandardCharsets.UTF_8));
+        InvocationResponse invocationResponse = new InvocationResponse(200, "test log", "Unhandled", errorDescription, Instant.now(), Instant.now());
+
+        task.handleResponse(invocationResponse, new AtomicInteger(0), Arrays.asList(501,504), 3, 1L);
+
+    }
+
+    @Test
+    public void testHandleResponseWhenFunctionInvocationAndExecutionSucceeds() {
+
+        LambdaSinkTask task = new LambdaSinkTask();
+        InvocationResponse invocationResponse = new InvocationResponse(200, "test log", "", null, Instant.now(), Instant.now());
+        AtomicInteger retryCounter = new AtomicInteger(2);
+
+        task.handleResponse(invocationResponse, retryCounter, Arrays.asList(501,504), 3, 1L);
+
+        Assert.assertEquals(0, retryCounter.intValue());
+    }
+
 }

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
@@ -48,7 +48,7 @@ public class LambdaSinkTaskTest {
         InvocationClient mockedClient = mock(InvocationClient.class);
 
         when(mockedClient.invoke(any()))
-            .thenReturn(new InvocationResponse(200, "test log", "", Instant.now(), Instant.now()));
+            .thenReturn(new InvocationResponse(200, "test log", "", null, Instant.now(), Instant.now()));
 
         Schema testSchema = SchemaBuilder.struct().name("com.nordstrom.kafka.connect.lambda.foo").field("bar", STRING_SCHEMA).build();
 


### PR DESCRIPTION
Maybe this behaviour should be configurable, but this will at least not swallow any function execution error that occurs.

Fixes https://github.com/Nordstrom/kafka-connect-lambda/issues/35

Sample log output:

```
connect_1          | [2020-05-29 09:30:46,649] ERROR WorkerSinkTask{id=example-lambda-connector-0} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted. (org.apache.kafka.connect.runtime.WorkerSinkTask)
connect_1          | com.nordstrom.kafka.connect.lambda.LambdaSinkTask$FunctionExecutionException: Lambda function execution failed. Reason: Unhandled: {"errorMessage": "SDSADSDDS", "errorType": "ValueError", "stackTrace": ["  File \"/var/task/lambda_function.py\", line 5, in lambda_handler\n    raise ValueError(\"SDSADSDDS\")\n"]}
connect_1          | 	at com.nordstrom.kafka.connect.lambda.LambdaSinkTask.handleResponse(LambdaSinkTask.java:215)
connect_1          | 	at com.nordstrom.kafka.connect.lambda.LambdaSinkTask.invoke(LambdaSinkTask.java:199)
connect_1          | 	at com.nordstrom.kafka.connect.lambda.LambdaSinkTask.put(LambdaSinkTask.java:86)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:538)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:224)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:192)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
connect_1          | 	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
connect_1          | 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
connect_1          | 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
connect_1          | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
connect_1          | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
connect_1          | 	at java.lang.Thread.run(Thread.java:748)
```