### PR TITLE
Update Kafka Connect to 2.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Kafka Connect sink plugin to invoke AWS Lambda functions.
 |1.1.0|2.2.0|1.11.592|
 |1.1.1|2.2.0|1.11.592|
 |1.2.0|2.3.0|1.11.651|
+|1.3.0|2.8.1|1.11.1034|
 
 Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.1 and earlier may not work with Kafka Connect versions greater than 2.2
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nordstrom.kafka.connect.lambda</groupId>
     <artifactId>kafka-connect-lambda</artifactId>
-    <version>1.2.2</version>
+    <version>1.3.0</version>
 
     <name>kafka-connect-lambda</name>
     <description>A Kafka Connect Connector for kafka-connect-lambda</description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 
         <kafka-connect.version>2.8.1</kafka-connect.version>
         <jackson.version>2.12.6</jackson.version>
-        <aws-java-sdk.version>1.11.651</aws-java-sdk.version>
-        <junit.version>4.13.1</junit.version>
+        <aws-java-sdk.version>1.11.1034</aws-java-sdk.version>
+        <junit.version>4.13.2</junit.version>
         <mockito-core.version>2.28.2</mockito-core.version>
         <google.guava.version>30.1.1-jre</google.guava.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,6 @@
                                     <exclude>mockito-all:*</exclude>
 
                                     <!-- provided by kafka-connect -->
-                                    <exclude>commons-codec:*</exclude>
-                                    <exclude>commons-logging:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
                                     <exclude>javax.ws.rs:*</exclude>
                                 </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,7 @@
 
         <slf4j.version>1.7.25</slf4j.version>
 
-        <kafka-connect.version>2.7.2</kafka-connect.version>
-        <!-- NB: must be consistent with version in kafka-connect -->
+        <kafka-connect.version>2.8.1</kafka-connect.version>
         <jackson.version>2.12.6</jackson.version>
         <aws-java-sdk.version>1.11.651</aws-java-sdk.version>
         <junit.version>4.13.1</junit.version>
@@ -221,6 +220,5 @@
         <name>Nordstrom, Inc.</name>
         <url>https://www.nordstrom.com</url>
     </organization>
-
 
 </project>


### PR DESCRIPTION
Make incremental update to Kafka Connect and AWS SDK.

Also includes extra dependencies in the release artifact to address #34 and #38.