### PR TITLE
Upgrade AWS SDK to version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ bin/
 .idea/
 *.iml
 
+# VS Code
+.vscode/
+
 # maven-shade-plugin
 dependency-reduced-pom.xml
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Kafka Connect sink plugin to invoke AWS Lambda functions.
 |1.1.1|2.2.0|1.11.592|
 |1.2.0|2.3.0|1.11.651|
 |1.3.0|2.8.1|1.11.1034|
+|1.4.0|3.8.1|2.29.47|
 
 Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.1 and earlier may not work with Kafka Connect versions greater than 2.2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: confluentinc/cp-zookeeper:7.8.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     ports:
@@ -10,7 +10,7 @@ services:
     logging: { driver: none }
 
   broker:
-    image: confluentinc/cp-kafka:5.3.1
+    image: confluentinc/cp-kafka:7.8.0
     ports:
     - 9092:9092
     environment:
@@ -31,7 +31,7 @@ services:
     logging: { driver: none }
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: confluentinc/cp-schema-registry:7.8.0
     hostname: schema-registry
     ports:
     - 8080:8080
@@ -48,7 +48,7 @@ services:
 
   # NB: run connect locally in stand-alone mode to debug
   connect:
-    image: confluentinc/cp-kafka-connect:5.3.1
+    image: confluentinc/cp-kafka-connect:7.8.0
     ports:
     - 8083:8083
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nordstrom.kafka.connect.lambda</groupId>
     <artifactId>kafka-connect-lambda</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <name>kafka-connect-lambda</name>
     <description>A Kafka Connect Connector for kafka-connect-lambda</description>
@@ -17,12 +17,12 @@
 
         <slf4j.version>1.7.25</slf4j.version>
 
-        <kafka-connect.version>2.8.1</kafka-connect.version>
-        <jackson.version>2.13.4.2</jackson.version>
-        <aws-java-sdk.version>1.11.1034</aws-java-sdk.version>
+        <kafka-connect.version>3.8.1</kafka-connect.version>
+        <jackson.version>2.18.2</jackson.version>
+        <aws-java-sdk.version>2.29.47</aws-java-sdk.version>
         <junit.version>4.13.2</junit.version>
-        <mockito-core.version>2.28.2</mockito-core.version>
-        <google.guava.version>32.0.0-jre</google.guava.version>
+        <mockito-core.version>5.15.2</mockito-core.version>
+        <google.guava.version>33.4.0-jre</google.guava.version>
     </properties>
 
     <dependencyManagement>
@@ -32,8 +32,8 @@
             specify their versions.
             -->
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
                 <version>${aws-java-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -77,12 +77,24 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-lambda</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lambda</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/InvocationClientConfigTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/InvocationClientConfigTest.java
@@ -2,7 +2,7 @@ package com.nordstrom.kafka.connect.lambda;
 
 import org.apache.kafka.common.config.ConfigException;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import com.nordstrom.kafka.connect.auth.AWSAssumeRoleCredentialsProvider;
 
 import java.time.Duration;
@@ -27,8 +27,8 @@ public class InvocationClientConfigTest {
         assertEquals(InvocationMode.SYNC, builder.getInvocationMode());
         assertEquals(InvocationFailure.STOP, builder.getFailureMode());
         assertEquals(Duration.ofMinutes(5), builder.getInvocationTimeout());
-        assertNotNull(builder.getClientConfiguration());
-        assertEquals(DefaultAWSCredentialsProviderChain.class, builder.getCredentialsProvider().getClass());
+        assertNotNull(builder.getHttpClient());
+        assertEquals(DefaultCredentialsProvider.class, builder.getCredentialsProvider().getClass());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class InvocationClientConfigTest {
         assertEquals(123, builder.getInvocationTimeout().toMillis());
         assertEquals(InvocationMode.SYNC, builder.getInvocationMode());
         assertEquals(InvocationFailure.DROP, builder.getFailureMode());
-        assertNotNull(builder.getClientConfiguration());
+        assertNotNull(builder.getHttpClient());
 
         assertEquals(AWSAssumeRoleCredentialsProvider.class, builder.getCredentialsProvider().getClass());
         AWSAssumeRoleCredentialsProvider credentialsProvider = (AWSAssumeRoleCredentialsProvider)builder.getCredentialsProvider();

--- a/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/lambda/LambdaSinkTaskTest.java
@@ -1,8 +1,5 @@
 package com.nordstrom.kafka.connect.lambda;
 
-import com.amazonaws.services.lambda.model.InvocationType;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -17,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
-import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Upgrade to AWS SDK v2 because v1 will be EOL by the end of the year (see https://aws.amazon.com/blogs/developer/the-aws-sdk-for-java-1-x-is-in-maintenance-mode-effective-july-31-2024/).
Also updated the other dependencies to newer versions.
For the migration I have used the tool provided by Amazon (https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-tool.html), but I had to manually fix a few things.