### PR TITLE
Unlist old versions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ A Kafka Connect sink plugin to invoke AWS Lambda functions.
 ## Compatibility Matrix
 |kafka-connect-lambda|Kafka Connect API|AWS SDK|
 |:---|:---|:---|
-|1.1.0|2.2.0|1.11.592|
-|1.1.1|2.2.0|1.11.592|
 |1.2.0|2.3.0|1.11.651|
 |1.3.0|2.8.1|1.11.1034|
 |1.4.0|3.8.1|2.29.47|
-
-Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.1 and earlier may not work with Kafka Connect versions greater than 2.2
 
 # Building
 


### PR DESCRIPTION
Removes the versions so old that we'd rather not mention them on the README.